### PR TITLE
Fix issue #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ In your jest config section of `package.json`, add the following entry:
         "reporters": [
             "reportportal-agent-jest",
             {
-            "endpoint": "https://your.reportportal.server/api/v1",
-            "project": "YourReportPortalProjectName"
+                "endpoint": "https://your.reportportal.server/api/v1",
+                "project": "YourReportPortalProjectName",
+                "launchname": "YourLauncherName",
+                "tags": ["Ninja","MyOtherCoolTag"]
             }
         ],
         ...
@@ -32,6 +34,14 @@ First configure your ReportPortal access token, then start Jest:
 $ export RP_TOKEN=<your_secure_token>
 $ jest
 ```
+
+It's also possible to override parameters `launchname` and `project` defined in `package.json` by using environment variables, it's important to mention that environment variables has precedence over `package.json` definition.
+
+```shell
+$ export RP_LAUNCH_NAME=MY_COOL_LAUNCHER
+$ export RP_PROJECT_NAME=MY_AWESOME_PROJECT
+```
+This for your convenience in case you has a continuous job that run your tests and may post the results pointing to a different Report Portal definition of project or launcher name.
 
 # Copyright Notice
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ const processor = (report, reporterOptions = {}) => {
   const rpClient = new RPClient({
     token: process.env.RP_TOKEN,
     endpoint: options.endpoint,
-    launch: 'Unit Tests',
+    launch: options.launchname,
     project: options.project,
   });
   const endTime = rpClient.helpers.now();

--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@ const getOptions = require('./utils/getOptions');
 const RPClient = require('reportportal-client');
 
 const reportTests = (client, launchObj, suiteObj, tests) => {
+
   tests.forEach((test) => {
+
     const {
       ancestorTitles,
       duration,
@@ -16,10 +18,17 @@ const reportTests = (client, launchObj, suiteObj, tests) => {
 
     const testObj = client.startTestItem({
       name: title,
-      type: 'TEST',
+      type: 'TEST'
     }, launchObj.tempId, suiteObj.tempId);
 
+    // Change status from 'pending' to 'skipped' so the launch finish
+    // the ran, instead of stay in running status forever.
+    const testStatus = test.status === 'pending' ? 'skipped' : test.status;
+
     const testFinishObj = client.finishTestItem(testObj.tempId, {
+      status: testStatus,
+      end_time: client.helpers.now(),
+      issue: test.issue
     });
 
   });
@@ -70,13 +79,14 @@ const processor = (report, reporterOptions = {}) => {
   const rpClient = new RPClient({
     token: process.env.RP_TOKEN,
     endpoint: options.endpoint,
-    launch: options.launchname,
-    project: options.project,
+    launch: process.env.RP_LAUNCH_NAME || options.launchname || 'Unit Tests',
+    project: process.env.RP_PROJECT_NAME || options.project
   });
   const endTime = rpClient.helpers.now();
 
   const launchObj = rpClient.startLaunch({
-    name: options.launchname,
+    name: process.env.RP_LAUNCH_NAME || options.launchname || 'Unit Tests',
+    tags: options.tags,
     start_time: report.startTime,
   });
 

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ const processor = (report, reporterOptions = {}) => {
   const endTime = rpClient.helpers.now();
 
   const launchObj = rpClient.startLaunch({
-    name: 'Unit Tests',
+    name: options.launchname,
     start_time: report.startTime,
   });
 


### PR DESCRIPTION
This commit fixes some issues:
- Test status (failed / skipped) not posted into ReportPortal.
- Tests in 'pending' status are changed to 'skipped' so the
_Suite_ run its properly finished, instead of _stay running forever_.

Also:
- Enhance to allow configurable parameters as environment
variables or config in package.json
- Possible to config 'tags' on the reporter