### PR TITLE
fix: doesn't start a suite if test has no describe

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,8 @@ class JestReportPortal {
     }
 
     _startSuite(suiteName, path) {
+        if (!suiteName) return;
+        
         const codeRef = getCodeRef(path, suiteName);
         const { tempId, promise } = this.client.startTestItem(getSuiteStartObject(suiteName, codeRef),
             this.tempLaunchId);
@@ -166,6 +168,8 @@ class JestReportPortal {
     }
 
     _finishSuite() {
+        if (!this.tempSuiteId) return;
+
         const { promise } = this.client.finishTestItem(this.tempSuiteId, {});
 
         promiseErrorHandler(promise);

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ class JestReportPortal {
 
     _startSuite(suiteName, path) {
         if (!suiteName) return;
-        
+
         const codeRef = getCodeRef(path, suiteName);
         const { tempId, promise } = this.client.startTestItem(getSuiteStartObject(suiteName, codeRef),
             this.tempLaunchId);


### PR DESCRIPTION
The following error: https://github.com/reportportal/agent-js-jest/issues/60 is caused by having tests without a describe, as in the example provided by the issue creator.

When a test is not wrapped within a describe, then `const suiteName = testResult.testResults[0].ancestorTitles` is an empty array and starting the suite throws an error because the name key is undefined.