### PR TITLE
Treat unknown test statuses as "skipped"

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -277,19 +277,6 @@ describe('index script', () => {
             expect(spyFinishPassedTest).not.toHaveBeenCalled();
             expect(spyFinishFailedTest).not.toHaveBeenCalled();
         });
-
-        test('_finishPassedTest, _finishFailedTest, _finishSkippedTest should not be called if test'
-            + ' status doesn\'t exist', () => {
-            const spyFinishPassedTest = jest.spyOn(reporter, '_finishPassedTest');
-            const spyFinishFailedTest = jest.spyOn(reporter, '_finishFailedTest');
-            const spyFinishSkippedTest = jest.spyOn(reporter, '_finishSkippedTest');
-
-            reporter._finishTest({ status: 'random', failureMessages: [] });
-
-            expect(spyFinishSkippedTest).not.toHaveBeenCalled();
-            expect(spyFinishPassedTest).not.toHaveBeenCalled();
-            expect(spyFinishFailedTest).not.toHaveBeenCalled();
-        });
     });
 
     describe('_finishSuite', () => {

--- a/index.js
+++ b/index.js
@@ -117,12 +117,8 @@ class JestReportPortal {
         case testItemStatuses.FAILED:
             this._finishFailedTest(errorMsg, isRetried);
             break;
-        case testItemStatuses.SKIPPED:
-            this._finishSkippedTest(isRetried);
-            break;
         default:
-            // eslint-disable-next-line no-console
-            console.log('Unsupported test Status!!!');
+            this._finishSkippedTest(isRetried);
         }
     }
 


### PR DESCRIPTION
_finishTest does not handle 'todo', 'pending', and 'disabled'.  These can cause the test run to never be 'closed', leaving the launch hanging in limbo.

This change treats all unknown entries as "skipped", and close them properly.