### PR TITLE
set duration of suites & tests

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -38,6 +38,7 @@ const testResult = {
             ancestorTitles: ['Suite name'],
             failureMessages: 'error message',
             invocations: 1,
+            duration: 5,
         },
     ],
 };
@@ -111,7 +112,7 @@ describe('index script', () => {
 
             reporter.onTestResult(testObj, testResult);
 
-            expect(spyStartSuite).toHaveBeenCalledWith(testResult.testResults[0].ancestorTitles[0], testObj.path);
+            expect(spyStartSuite).toHaveBeenCalledWith(testResult.testResults[0].ancestorTitles[0], 5, testObj.path);
             expect(spyStartTest).toHaveBeenCalledWith(testResult.testResults[0], false, testObj.path);
             expect(spyFinishTest).toHaveBeenCalledWith(testResult.testResults[0], false);
             expect(spyFinishSuite).toHaveBeenCalled();
@@ -193,11 +194,11 @@ describe('index script', () => {
                 type: 'SUITE',
                 name: 'suite name',
                 codeRef: 'example.js/suite name',
-                startTime: new Date().valueOf(),
+                startTime: new Date().valueOf() - 5,
             };
             reporter.tempLaunchId = 'tempLaunchId';
 
-            reporter._startSuite('suite name', testObj.path);
+            reporter._startSuite('suite name', 5, testObj.path);
 
             expect(reporter.client.startTestItem).toHaveBeenCalledWith(expectedStartTestItemParameter, 'tempLaunchId');
             expect(reporter.tempSuiteId).toEqual('startTestItem');
@@ -212,11 +213,16 @@ describe('index script', () => {
                 name: 'test name',
                 codeRef: 'example.js/rootDescribe/test name',
                 retry: true,
+                startTime: new Date().valueOf() - 5,
             };
             reporter.tempLaunchId = 'tempLaunchId';
             reporter.tempSuiteId = 'tempSuiteId';
 
-            reporter._startTest({ title: 'test name', ancestorTitles: ['rootDescribe'] }, true, testObj.path);
+            reporter._startTest({
+                title: 'test name',
+                duration: 5,
+                ancestorTitles: ['rootDescribe'],
+            }, true, testObj.path);
 
             expect(reporter.client.startTestItem)
                 .toHaveBeenCalledWith(expectedStartTestItemParameter, 'tempLaunchId', 'tempSuiteId');

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class JestReportPortal {
         const suiteName = testResult.testResults[0].ancestorTitles[0];
 
         var duration = 0;
-        for (var result in testResult.testResults) {
+        for (let result = 0; i < testResult.testResults.length; i++) {
             duration += testResult.testResults[result].duration;
         }
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class JestReportPortal {
         const suiteName = testResult.testResults[0].ancestorTitles[0];
 
         var duration = 0;
-        for (let result = 0; i < testResult.testResults.length; i++) {
+        for (let result = 0; result < testResult.testResults.length; result++) {
             duration += testResult.testResults[result].duration;
         }
 


### PR DESCRIPTION
Set the start time of tests as `now - duration`, and the start time of suite as `now - sum of all test durations`.

While not the real start time, this allow Report Portal to display duration for tests and suites