### PR TITLE
Add new option logLaunchLink to print Launch URL in console

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ In your jest config section of `package.json`, add the following entry:
                 "project": "YourReportPortalProjectName",
                 "launch": "YourLauncherName",
                 "description": "YourDescription",
+                "logLaunchLink": true,
                 "attributes": [
                     {
                         "key": "YourKey",
@@ -60,6 +61,7 @@ module.exports = {
                 "project": "YourReportPortalProjectName",
                 "launch": "YourLauncherName",
                 "description": "YourDescription",
+                "logLaunchLink": true,
                 "attributes": [
                     {
                         "key": "YourKey",

--- a/__tests__/mocks/reportportal-client.mock.js
+++ b/__tests__/mocks/reportportal-client.mock.js
@@ -20,6 +20,7 @@ const reporterOptions = {
     project: 'projectName',
     launch: 'launcherName',
     description: 'description',
+    logLaunchLink: true,
     attributes: [
         {
             key: 'YourKey',

--- a/index.js
+++ b/index.js
@@ -91,6 +91,12 @@ class JestReportPortal {
     onRunComplete() {
         const { promise } = this.client.finishLaunch(this.tempLaunchId);
 
+        if (this.reportOptions.logLaunchLink === true) {
+            promise.then(response => {
+                console.log(`\nReportPortal Launch Link: ${response.link}`)
+            });
+        }
+
         promiseErrorHandler(promise);
     }
 

--- a/utils/objectUtils.js
+++ b/utils/objectUtils.js
@@ -85,6 +85,7 @@ const getClientInitObject = (options = {}) => {
         mode: options.mode,
         debug: options.debug,
         restClientConfig: options.restClientConfig,
+        logLaunchLink: options.logLaunchLink,
     };
 };
 


### PR DESCRIPTION
Add a new option in the `jest-reportportal.conf.js` or `jest.config.js` to print the URL of the Launch of the tests.

The idea is to provide a way to easily verify the result of the tests after the execution.

An example of the object:
```json
{
    "jest": {
        "reporters": [
            "default",
            ["@reportportal/agent-js-jest",
            {
                "token": "00000000-0000-0000-0000-000000000000",
                "endpoint": "https://your.reportportal.server/api/v1",
                "project": "YourReportPortalProjectName",
                "launch": "YourLauncherName",
                "description": "YourDescription",
                "logLaunchLink": true,
                "attributes": [
                    {
                        "key": "YourKey",
                        "value": "YourValue"
                    },
                    {
                        "value": "YourValue"
                    },
                ],
                "restClientConfig": {
                  "timeout": 0
                }
            }]
        ],
    }
}
```

And then in the finish of the execution the Launch Link will be printed:

`ReportPortal Launch Link: http://host/ui/#project_name/launches/all/id`