### PR TITLE
Fix URL - use /api/v1 instead of /api/v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ module.exports = {
             '@reportportal/agent-js-jest',
             {
                 apiKey: 'reportportalApiKey',
-                endpoint: 'https://your.reportportal.server/api/v2',
+                endpoint: 'https://your.reportportal.server/api/v1',
                 project: 'Your reportportal project name',
                 launch: 'Your launch name',
                 attributes: [
@@ -54,7 +54,7 @@ In case you use the jest config section of `package.json`, add the following ent
             ["@reportportal/agent-js-jest",
             {
                 "token": "reportportalApiKey",
-                "endpoint": "https://your.reportportal.server/api/v2",
+                "endpoint": "https://your.reportportal.server/api/v1",
                 "project": "Your reportportal project name",
                 "launch": "Your launch name",
                 "attributes": [


### PR DESCRIPTION
If I use `/api/v2` as stated in documentation, I get the following error:

```
Error: timeout of 30000ms exceeded
URL: http://localhost:8080/api/v2/superadmin_personal/item/b6bd3553-19db-4e23-9f72-77f9c8cddfb4
method: POST
    at /home/maksrafalko/apps/nodejs/fxpro/payments-e2e/node_modules/@reportportal/client-javascript/lib/rest.js:41:15
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
Error: timeout of 30000ms exceeded
URL: http://localhost:8080/api/v2/superadmin_personal/item/b6bd3553-19db-4e23-9f72-77f9c8cddfb4
method: POST
    at /home/maksrafalko/apps/nodejs/fxpro/payments-e2e/node_modules/@reportportal/client-javascript/lib/rest.js:41:15
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
Error: timeout of 30000ms exceeded
URL: http://localhost:8080/api/v2/superadmin_personal/item/b6bd3553-19db-4e23-9f72-77f9c8cddfb4
method: POST
    at /home/maksrafalko/apps/nodejs/fxpro/payments-e2e/node_modules/@reportportal/client-javascript/lib/rest.js:41:15
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

With `/api/v1` everything works as expected.

Please note that in the examples repository, `/api/v1` is used:

https://github.com/reportportal/examples-js/blob/d9c8669cd5d36e357ae4d1e0e9136b4ea4777045/example-jest/jest.config.js#L10