### PR TITLE
fix: remove race condition where many suites run in parallel

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -40,6 +40,9 @@ const systemAttr = {
 };
 
 describe('index script', () => {
+  /**
+   * @type {JestReportPortal}
+   */
   let reporter;
 
   beforeAll(() => {
@@ -371,7 +374,14 @@ describe('index script', () => {
       const spyFinishFailedTest = jest.spyOn(reporter, '_finishFailedStep');
       const spyFinishSkippedTest = jest.spyOn(reporter, '_finishSkippedStep');
 
-      reporter._finishStep({ status: TEST_ITEM_STATUSES.PASSED, failureMessages: [] });
+      reporter.tempStepIds.set('/fake test', 'tempStepId');
+
+      reporter._finishStep({
+        status: TEST_ITEM_STATUSES.PASSED,
+        failureMessages: [],
+        ancestorTitles: [],
+        title: 'fake test',
+      });
 
       expect(spyFinishPassedTest).toHaveBeenCalled();
       expect(spyFinishFailedTest).not.toHaveBeenCalled();
@@ -383,12 +393,19 @@ describe('index script', () => {
       const spyFinishFailedTest = jest.spyOn(reporter, '_finishFailedStep');
       const spyFinishSkippedTest = jest.spyOn(reporter, '_finishSkippedStep');
 
+      reporter.tempStepIds.set('/fake test', 'tempStepId');
+
       reporter._finishStep(
-        { status: TEST_ITEM_STATUSES.FAILED, failureMessages: ['error message'] },
+        {
+          status: TEST_ITEM_STATUSES.FAILED,
+          failureMessages: ['error message'],
+          ancestorTitles: [],
+          title: 'fake test',
+        },
         false,
       );
 
-      expect(spyFinishFailedTest).toHaveBeenCalledWith('error message');
+      expect(spyFinishFailedTest).toHaveBeenCalledWith('tempStepId', 'error message');
       expect(spyFinishPassedTest).not.toHaveBeenCalled();
       expect(spyFinishSkippedTest).not.toHaveBeenCalled();
     });
@@ -398,7 +415,14 @@ describe('index script', () => {
       const spyFinishFailedTest = jest.spyOn(reporter, '_finishFailedStep');
       const spyFinishSkippedTest = jest.spyOn(reporter, '_finishSkippedStep');
 
-      reporter._finishStep({ status: TEST_ITEM_STATUSES.SKIPPED, failureMessages: [] });
+      reporter.tempStepIds.set('/fake test', 'tempStepId');
+
+      reporter._finishStep({
+        status: TEST_ITEM_STATUSES.SKIPPED,
+        failureMessages: [],
+        ancestorTitles: [],
+        title: 'fake test',
+      });
 
       expect(spyFinishSkippedTest).toHaveBeenCalled();
       expect(spyFinishPassedTest).not.toHaveBeenCalled();
@@ -447,7 +471,7 @@ describe('index script', () => {
       };
       reporter.tempStepId = 'tempStepId';
 
-      reporter._finishPassedStep(false);
+      reporter._finishPassedStep('tempStepId', false);
 
       expect(reporter.client.finishTestItem).toHaveBeenCalledWith(
         'tempStepId',
@@ -467,9 +491,13 @@ describe('index script', () => {
       };
       reporter.tempStepId = tempStepId;
 
-      reporter._finishFailedStep(errorMessage, false);
+      reporter._finishFailedStep('tempStepId', errorMessage, false);
 
-      expect(spySendLog).toHaveBeenCalledWith({ message: errorMessage, level: LOG_LEVEL.ERROR });
+      expect(spySendLog).toHaveBeenCalledWith({
+        message: errorMessage,
+        level: LOG_LEVEL.ERROR,
+        tempStepId: 'tempStepId',
+      });
       expect(reporter.client.finishTestItem).toHaveBeenCalledWith(
         tempStepId,
         expectedFinishTestItemParameter,
@@ -486,7 +514,7 @@ describe('index script', () => {
         reporter.tempStepId = 'tempStepId';
         reporter.reportOptions.extendTestDescriptionWithLastError = false;
 
-        reporter._finishFailedStep('error message', false);
+        reporter._finishFailedStep('tempStepId', 'error message', false);
 
         expect(reporter.client.finishTestItem).toHaveBeenCalledWith(
           'tempStepId',
@@ -503,7 +531,7 @@ describe('index script', () => {
       };
       reporter.tempStepId = 'tempStepId';
 
-      reporter._finishSkippedStep(false);
+      reporter._finishSkippedStep('tempStepId', false);
 
       expect(reporter.client.finishTestItem).toHaveBeenCalledWith(
         'tempStepId',
@@ -519,7 +547,7 @@ describe('index script', () => {
       reporter.tempStepId = 'tempStepId';
       reporter.reportOptions.skippedIssue = false;
 
-      reporter._finishSkippedStep(false);
+      reporter._finishSkippedStep('tempStepId', false);
 
       expect(reporter.client.finishTestItem).toHaveBeenCalledWith(
         'tempStepId',

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@reportportal/agent-js-jest",
-      "version": "5.0.8",
+      "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@reportportal/client-javascript": "~5.1.4",

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -201,27 +201,35 @@ class JestReportPortal {
   _finishStep(test) {
     const errorMsg = test.failureMessages[0];
 
+    const fullName = getFullStepName(test);
+    const tempStepId = this.tempStepIds.get(fullName);
+
+    if (tempStepId === undefined) {
+      console.error(`Could not finish Test Step - "${fullName}"`);
+      return;
+    }
+
     switch (test.status) {
       case TEST_ITEM_STATUSES.PASSED:
-        this._finishPassedStep();
+        this._finishPassedStep(tempStepId);
         break;
       case TEST_ITEM_STATUSES.FAILED:
-        this._finishFailedStep(errorMsg);
+        this._finishFailedStep(tempStepId, errorMsg);
         break;
       default:
-        this._finishSkippedStep();
+        this._finishSkippedStep(tempStepId);
     }
   }
 
-  _finishPassedStep() {
+  _finishPassedStep(tempStepId) {
     const status = TEST_ITEM_STATUSES.PASSED;
-    const { promise } = this.client.finishTestItem(this.tempStepId, { status });
+    const { promise } = this.client.finishTestItem(tempStepId, { status });
 
     promiseErrorHandler(promise);
     this.promises.push(promise);
   }
 
-  _finishFailedStep(failureMessage) {
+  _finishFailedStep(tempStepId, failureMessage) {
     const status = TEST_ITEM_STATUSES.FAILED;
     const description =
       this.reportOptions.extendTestDescriptionWithLastError === false
@@ -229,18 +237,18 @@ class JestReportPortal {
         : `\`\`\`error\n${stripAnsi(failureMessage)}\n\`\`\``;
     const finishTestObj = { status, ...(description && { description }) };
 
-    this.sendLog({ message: failureMessage, level: LOG_LEVEL.ERROR });
+    this.sendLog({ message: failureMessage, level: LOG_LEVEL.ERROR, tempStepId });
 
-    const { promise } = this.client.finishTestItem(this.tempStepId, finishTestObj);
+    const { promise } = this.client.finishTestItem(tempStepId, finishTestObj);
 
     promiseErrorHandler(promise);
     this.promises.push(promise);
   }
 
-  sendLog({ level = LOG_LEVEL.INFO, message = '', file, time }) {
+  sendLog({ level = LOG_LEVEL.INFO, message = '', file, time, tempStepId }) {
     const newMessage = stripAnsi(message);
     const { promise } = this.client.sendLog(
-      this.tempStepId,
+      tempStepId === undefined ? this.tempStepId : tempStepId,
       {
         message: newMessage,
         level,
@@ -253,14 +261,14 @@ class JestReportPortal {
     this.promises.push(promise);
   }
 
-  _finishSkippedStep() {
+  _finishSkippedStep(tempStepId) {
     const status = 'skipped';
     const issue = this.reportOptions.skippedIssue === false ? { issueType: 'NOT_ISSUE' } : null;
     const finishTestObj = {
       status,
       ...(issue && { issue }),
     };
-    const { promise } = this.client.finishTestItem(this.tempStepId, finishTestObj);
+    const { promise } = this.client.finishTestItem(tempStepId, finishTestObj);
 
     promiseErrorHandler(promise);
     this.promises.push(promise);


### PR DESCRIPTION
Hello! I was attempting to implement the Report Portal jest reporter into our test project when I came across an interesting error. Here's what I was presented with in my console when I received the failure:

```
info: Started test "test 1" fx671t90m2m7mmx4
info: Started test "test 2" fx671t90m2m7mmx6
info: Started test "test 3" fx671t90m2m7mmx8
info: finishing step "test 2" fx671t90m2m7mmx8
info: Started test "test 4" fx671t90m2m7mmx9
info: finishing step "test 3" fx671t90m2m7mmx9
info: finishing step "test 4" fx671t90m2m7mmx9
info: finishing step "test 1" fx671t90m2m7mmx9
error: Error: Item with tempId "fx671t90m2m7mmx9" not found
```

I discovered that, since our tests run in parallel, the value of `JestReportPortal.tempStepId` was repeatedly getting modified and re-used when finishing test steps, causing the error. After modifying the `JestReportPortal._finishStep` method to look into `tempStepIds`, the issue no longer happens. I had attempted to remove the reliance on `JestReportPortal.tempStepId` entirely, but it seems like the `ReportingApi` doesn't have a good way of knowing the name of the current test (at least, one that matches the format of `tempStepIds`. The only thing I could see that could be used was `global.expect.getState().currentTestName`, but that's delimited by spaces instead of forward slashes. Theoretically, the reporter could be modified to use space-delimited names and likely fully support concurrent execution.

Please let me know if you need anything else for this PR to be accepted. The issue I was having was a bit tough to test since it relies on tests being finished in a specific order, but I can attempt to do so if necessary. Thanks!